### PR TITLE
Fixes readout of packages in delivery

### DIFF
--- a/src/delivery.c
+++ b/src/delivery.c
@@ -940,9 +940,11 @@ void delivery_conda_show(struct Delivery *ctx) {
     printf("%-20s %-10s\n", "Prefix:", ctx->storage.conda_install_prefix);
 
     puts("Native Packages:");
-    if (strlist_count(ctx->conda.conda_packages)) {
+    if (strlist_count(ctx->conda.conda_packages) || strlist_count(ctx->conda.conda_packages_defer)) {
         struct StrList *list_conda = strlist_init();
-        strlist_append_strlist(list_conda, ctx->conda.conda_packages);
+        if (strlist_count(ctx->conda.conda_packages)) {
+            strlist_append_strlist(list_conda, ctx->conda.conda_packages);
+        }
         if (strlist_count(ctx->conda.conda_packages_defer)) {
             strlist_append_strlist(list_conda, ctx->conda.conda_packages_defer);
         }
@@ -961,9 +963,11 @@ void delivery_conda_show(struct Delivery *ctx) {
     }
 
     puts("Python Packages:");
-    if (strlist_count(ctx->conda.pip_packages)) {
+    if (strlist_count(ctx->conda.pip_packages) || strlist_count(ctx->conda.pip_packages_defer)) {
         struct StrList *list_python = strlist_init();
-        strlist_append_strlist(list_python, ctx->conda.pip_packages);
+        if (strlist_count(ctx->conda.pip_packages)) {
+            strlist_append_strlist(list_python, ctx->conda.pip_packages);
+        }
         if (strlist_count(ctx->conda.pip_packages_defer)) {
             strlist_append_strlist(list_python, ctx->conda.pip_packages_defer);
         }

--- a/src/delivery.c
+++ b/src/delivery.c
@@ -941,26 +941,42 @@ void delivery_conda_show(struct Delivery *ctx) {
 
     puts("Native Packages:");
     if (strlist_count(ctx->conda.conda_packages)) {
-        for (size_t i = 0; i < strlist_count(ctx->conda.conda_packages); i++) {
-            char *token = strlist_item(ctx->conda.conda_packages, i);
+        struct StrList *list_conda = strlist_init();
+        strlist_append_strlist(list_conda, ctx->conda.conda_packages);
+        if (strlist_count(ctx->conda.conda_packages_defer)) {
+            strlist_append_strlist(list_conda, ctx->conda.conda_packages_defer);
+        }
+        strlist_sort(list_conda, STASIS_SORT_ALPHA);
+        
+        for (size_t i = 0; i < strlist_count(list_conda); i++) {
+            char *token = strlist_item(list_conda, i);
             if (isempty(token) || isblank(*token) || startswith(token, "-")) {
                 continue;
             }
             printf("%21s%s\n", "", token);
         }
+        guard_strlist_free(&list_conda);
     } else {
        printf("%21s%s\n", "", "N/A");
     }
 
     puts("Python Packages:");
     if (strlist_count(ctx->conda.pip_packages)) {
-        for (size_t i = 0; i < strlist_count(ctx->conda.pip_packages); i++) {
-            char *token = strlist_item(ctx->conda.pip_packages, i);
+        struct StrList *list_python = strlist_init();
+        strlist_append_strlist(list_python, ctx->conda.pip_packages);
+        if (strlist_count(ctx->conda.pip_packages_defer)) {
+            strlist_append_strlist(list_python, ctx->conda.pip_packages_defer);
+        }
+        strlist_sort(list_python, STASIS_SORT_ALPHA);
+
+        for (size_t i = 0; i < strlist_count(list_python); i++) {
+            char *token = strlist_item(list_python, i);
             if (isempty(token) || isblank(*token) || startswith(token, "-")) {
                 continue;
             }
             printf("%21s%s\n", "", token);
         }
+        guard_strlist_free(&list_python);
     } else {
         printf("%21s%s\n", "", "N/A");
     }

--- a/tests/data/generic.ini
+++ b/tests/data/generic.ini
@@ -16,7 +16,7 @@ installer_arch = {{env:STASIS_CONDA_ARCH}}
 installer_baseurl = https://github.com/conda-forge/miniforge/releases/download/{{conda.installer_version}}
 ;conda_packages =
 pip_packages =
-    firewatch
+    firewatch==0.0.4
 
 
 [runtime]
@@ -24,7 +24,6 @@ PYTHONUNBUFFERED = 1
 
 
 [test:firewatch]
-version = 0.0.4
 repository = https://github.com/astroconda/firewatch
 script =
     pip install -e '.'


### PR DESCRIPTION
* Now that the overview is displayed after deferred packages are filtered out of the main list, filtered packages were no longer displayed
* This combines the main list and deferred list for both conda, and pip packages.