### PR TITLE
Fixes deprecated call to ENV in Dockerfile templates

### DIFF
--- a/mission/generic/Dockerfile.in
+++ b/mission/generic/Dockerfile.in
@@ -58,7 +58,7 @@ RUN curl -q -OSsL ${DIST_URL}/${DIST_INSTALLER} \
     && echo conda activate linux > /etc/profile.d/zconda.sh \
     && chown -R developer: ${OPT} ${HOME}
 # Configure Conda
-ENV PATH "${DIST_PATH}/bin:${PATH}"
+ENV PATH="${DIST_PATH}/bin:${PATH}"
 # Get delivery snapshot
 ADD ${SNAPSHOT_INPUT} ${HOME}/SNAPSHOT.yml
 ADD ${SNAPSHOT_PKGDIR} ${HOME}/packages

--- a/mission/hst/Dockerfile.in
+++ b/mission/hst/Dockerfile.in
@@ -58,7 +58,7 @@ RUN curl -q -OSsL ${DIST_URL}/${DIST_INSTALLER} \
     && echo conda activate linux > /etc/profile.d/zconda.sh \
     && chown -R developer: ${OPT} ${HOME}
 # Configure Conda
-ENV PATH "${DIST_PATH}/bin:${PATH}"
+ENV PATH="${DIST_PATH}/bin:${PATH}"
 # Get delivery snapshot
 ADD ${SNAPSHOT_INPUT} ${HOME}/SNAPSHOT.yml
 ADD ${SNAPSHOT_PKGDIR} ${HOME}/packages

--- a/mission/jwst/Dockerfile.in
+++ b/mission/jwst/Dockerfile.in
@@ -58,7 +58,7 @@ RUN curl -q -OSsL ${DIST_URL}/${DIST_INSTALLER} \
     && echo conda activate linux > /etc/profile.d/zconda.sh \
     && chown -R developer: ${OPT} ${HOME}
 # Configure Conda
-ENV PATH "${DIST_PATH}/bin:${PATH}"
+ENV PATH="${DIST_PATH}/bin:${PATH}"
 # Get delivery snapshot
 ADD ${SNAPSHOT_INPUT} ${HOME}/SNAPSHOT.yml
 ADD ${SNAPSHOT_PKGDIR} ${HOME}/packages

--- a/mission/roman/Dockerfile.in
+++ b/mission/roman/Dockerfile.in
@@ -58,7 +58,7 @@ RUN curl -q -OSsL ${DIST_URL}/${DIST_INSTALLER} \
     && echo conda activate linux > /etc/profile.d/zconda.sh \
     && chown -R developer: ${OPT} ${HOME}
 # Configure Conda
-ENV PATH "${DIST_PATH}/bin:${PATH}"
+ENV PATH="${DIST_PATH}/bin:${PATH}"
 # Get delivery snapshot
 ADD ${SNAPSHOT_INPUT} ${HOME}/SNAPSHOT.yml
 ADD ${SNAPSHOT_PKGDIR} ${HOME}/packages


### PR DESCRIPTION
```
LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line XY)
```
