### PR TITLE
Refactor ini getter and setter usage

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -37,6 +37,11 @@ jobs:
       run: |
         echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
 
+    - name: Update apt
+      if: matrix.os == 'ubuntu-latest'
+      run: >
+        sudo apt update
+
     - name: Install Linux dependencies
       if: matrix.os == 'ubuntu-latest'
       run: >

--- a/include/ini.h
+++ b/include/ini.h
@@ -14,17 +14,21 @@
 #define INI_SEARCH_SUBSTR 2
                                     ///< expanded to preserve runtime state.
 
-#define INIVAL_TYPE_INT 1           ///< Integer
-#define INIVAL_TYPE_UINT 2          ///< Unsigned integer
-#define INIVAL_TYPE_LONG 3          ///< Long integer
-#define INIVAL_TYPE_ULONG 4         ///< Unsigned long integer
-#define INIVAL_TYPE_LLONG 5         ///< Long long integer
-#define INIVAL_TYPE_ULLONG 6        ///< Unsigned long long integer
-#define INIVAL_TYPE_DOUBLE 7        ///< Double precision float
-#define INIVAL_TYPE_FLOAT 8         ///< Single precision float
-#define INIVAL_TYPE_STR 9           ///< String
-#define INIVAL_TYPE_STR_ARRAY 10    ///< String Array
-#define INIVAL_TYPE_BOOL 11         ///< Boolean
+#define INIVAL_TYPE_CHAR 1          ///< Byte
+#define INIVAL_TYPE_UCHAR 2         ///< Unsigned byte
+#define INIVAL_TYPE_SHORT 3         ///< Short integer
+#define INIVAL_TYPE_USHORT 4        ///< Unsigned short integer
+#define INIVAL_TYPE_INT 5           ///< Integer
+#define INIVAL_TYPE_UINT 6          ///< Unsigned integer
+#define INIVAL_TYPE_LONG 7          ///< Long integer
+#define INIVAL_TYPE_ULONG 8         ///< Unsigned long integer
+#define INIVAL_TYPE_LLONG 9         ///< Long long integer
+#define INIVAL_TYPE_ULLONG 10       ///< Unsigned long long integer
+#define INIVAL_TYPE_DOUBLE 11       ///< Double precision float
+#define INIVAL_TYPE_FLOAT 12        ///< Single precision float
+#define INIVAL_TYPE_STR 13          ///< String
+#define INIVAL_TYPE_STR_ARRAY 14    ///< String Array
+#define INIVAL_TYPE_BOOL 15         ///< Boolean
 
 #define INIVAL_TO_LIST 1 << 1
 
@@ -32,6 +36,10 @@
  * \brief Consolidate possible value types
  */
 union INIVal {
+    char as_char;                    ///< Byte
+    unsigned char as_uchar;          ///< Unsigned byte
+    short as_short;                  ///< Short integer
+    unsigned short as_ushort;        ///< Unsigned short integer
     int as_int;                      ///< Integer
     unsigned as_uint;                ///< Unsigned integer
     long as_long;                    ///< Long integer
@@ -226,4 +234,23 @@ int ini_write(struct INIFILE *ini, FILE **stream, unsigned mode);
  * @param ini
  */
 void ini_free(struct INIFILE **ini);
+
+int ini_getval_int(struct INIFILE *ini, char *section_name, char *key, int *state);
+unsigned int ini_getval_uint(struct INIFILE *ini, char *section_name, char *key, int *state);
+long ini_getval_long(struct INIFILE *ini, char *section_name, char *key, int *state);
+unsigned long ini_getval_ulong(struct INIFILE *ini, char *section_name, char *key, int *state);
+long long ini_getval_llong(struct INIFILE *ini, char *section_name, char *key, int *state);
+unsigned long long ini_getval_ullong(struct INIFILE *ini, char *section_name, char *key, int *state);
+float ini_getval_float(struct INIFILE *ini, char *section_name, char *key, int *state);
+double ini_getval_double(struct INIFILE *ini, char *section_name, char *key, int *state);
+bool ini_getval_bool(struct INIFILE *ini, char *section_name, char *key, int *state);
+short ini_getval_short(struct INIFILE *ini, char *section_name, char *key, int *state);
+unsigned short ini_getval_ushort(struct INIFILE *ini, char *section_name, char *key, int *state);
+char ini_getval_char(struct INIFILE *ini, char *section_name, char *key, int *state);
+unsigned char ini_getval_uchar(struct INIFILE *ini, char *section_name, char *key, int *state);
+char *ini_getval_char_p(struct INIFILE *ini, char *section_name, char *key, int *state);
+char *ini_getval_str(struct INIFILE *ini, char *section_name, char *key, int *state);
+char **ini_getval_char_array_p(struct INIFILE *ini, char *section_name, char *key, int *state);
+char **ini_getval_str_array(struct INIFILE *ini, char *section_name, char *key, int *state);
+struct StrList *ini_getval_strlist(struct INIFILE *ini, char *section_name, char *key, char *tok, int *state);
 #endif //STASIS_INI_H

--- a/include/ini.h
+++ b/include/ini.h
@@ -29,7 +29,7 @@
 #define INIVAL_TO_LIST 1 << 1
 
 /*! \union INIVal
- * \brief Consolidation possible value types
+ * \brief Consolidate possible value types
  */
 union INIVal {
     int as_int;                      ///< Integer
@@ -52,6 +52,7 @@ union INIVal {
 struct INIData {
     char *key;                       ///< INI variable name
     char *value;                     ///< INI variable value
+    unsigned type_hint;
 };
 
 /*! \struct INISection

--- a/src/delivery.c
+++ b/src/delivery.c
@@ -1229,7 +1229,7 @@ int delivery_get_installer(struct Delivery *ctx, char *installer_url) {
     sprintf(script_path, "%s/%s", ctx->storage.tmpdir, installer);
     if (access(script_path, F_OK)) {
         // Script doesn't exist
-        int fetch_status = download(installer_url, script_path, NULL);
+        long fetch_status = download(installer_url, script_path, NULL);
         if (HTTP_ERROR(fetch_status) || fetch_status < 0) {
             // download failed
             return -1;

--- a/src/ini.c
+++ b/src/ini.c
@@ -168,17 +168,26 @@ int ini_getval(struct INIFILE *ini, char *section_name, char *key, int type, uni
             result->as_float = (float) strtod(data->value, NULL);
             break;
         case INIVAL_TYPE_STR:
-            result->as_char_p = lstrip(data->value);
+            result->as_char_p = strdup(data->value);
+            if (!result->as_char_p) {
+                return -1;
+            }
+            lstrip(result->as_char_p);
             break;
         case INIVAL_TYPE_STR_ARRAY:
             strcpy(tbufp, data->value);
-            *data->value = '\0';
+            char *value = NULL;
+            size_t lines = num_chars(tbufp, '\n');
+            value = calloc(strlen(tbufp) + lines + 1, sizeof(*value));
+            if (!value) {
+                return -1;
+            }
             while ((token = strsep(&tbufp, "\n")) != NULL) {
                 lstrip(token);
-                strcat(data->value, token);
-                strcat(data->value, "\n");
+                strcat(value, token);
+                strcat(value, "\n");
             }
-            result->as_char_p = data->value;
+            result->as_char_p = value;
             break;
         case INIVAL_TYPE_BOOL:
             result->as_bool = false;

--- a/src/ini.c
+++ b/src/ini.c
@@ -123,6 +123,18 @@ int ini_getval(struct INIFILE *ini, char *section_name, char *key, int type, uni
         return -1;
     }
     switch (type) {
+        case INIVAL_TYPE_CHAR:
+            result->as_char = (char) strtol(data->value, NULL, 10);
+            break;
+        case INIVAL_TYPE_UCHAR:
+            result->as_uchar = (unsigned char) strtoul(data->value, NULL, 10);
+            break;
+        case INIVAL_TYPE_SHORT:
+            result->as_short = (short) strtol(data->value, NULL, 10);
+            break;
+        case INIVAL_TYPE_USHORT:
+            result->as_ushort = (unsigned short) strtoul(data->value, NULL, 10);
+            break;
         case INIVAL_TYPE_INT:
             result->as_int = (int) strtol(data->value, NULL, 10);
             break;
@@ -173,6 +185,107 @@ int ini_getval(struct INIFILE *ini, char *section_name, char *key, int type, uni
             break;
     }
     return 0;
+}
+
+#define getval_returns(t) return result.t
+#define getval_setup(t) \
+    union INIVal result; \
+    int state_local = 0; \
+    state_local = ini_getval(ini, section_name, key, t, &result); \
+    if (state != NULL) { \
+        *state = state_local; \
+    }
+
+int ini_getval_int(struct INIFILE *ini, char *section_name, char *key, int *state) {
+    getval_setup(INIVAL_TYPE_INT)
+    getval_returns(as_int);
+}
+
+unsigned int ini_getval_uint(struct INIFILE *ini, char *section_name, char *key, int *state) {
+    getval_setup(INIVAL_TYPE_UINT)
+    getval_returns(as_uint);
+}
+
+long ini_getval_long(struct INIFILE *ini, char *section_name, char *key, int *state) {
+    getval_setup(INIVAL_TYPE_LONG)
+    getval_returns(as_long);
+}
+
+unsigned long ini_getval_ulong(struct INIFILE *ini, char *section_name, char *key, int *state) {
+    getval_setup(INIVAL_TYPE_ULONG)
+    getval_returns(as_ulong);
+}
+
+long long ini_getval_llong(struct INIFILE *ini, char *section_name, char *key, int *state) {
+    getval_setup(INIVAL_TYPE_LLONG)
+    getval_returns(as_llong);
+}
+
+unsigned long long ini_getval_ullong(struct INIFILE *ini, char *section_name, char *key, int *state) {
+    getval_setup(INIVAL_TYPE_ULLONG)
+    getval_returns(as_ullong);
+}
+
+float ini_getval_float(struct INIFILE *ini, char *section_name, char *key, int *state) {
+    getval_setup(INIVAL_TYPE_FLOAT)
+    getval_returns(as_float);
+}
+
+double ini_getval_double(struct INIFILE *ini, char *section_name, char *key, int *state) {
+    getval_setup(INIVAL_TYPE_DOUBLE)
+    getval_returns(as_double);
+}
+
+bool ini_getval_bool(struct INIFILE *ini, char *section_name, char *key, int *state) {
+    getval_setup(INIVAL_TYPE_BOOL)
+    getval_returns(as_bool);
+}
+
+short ini_getval_short(struct INIFILE *ini, char *section_name, char *key, int *state) {
+    getval_setup(INIVAL_TYPE_SHORT)
+    getval_returns(as_short);
+}
+
+unsigned short ini_getval_ushort(struct INIFILE *ini, char *section_name, char *key, int *state) {
+    getval_setup(INIVAL_TYPE_USHORT)
+    getval_returns(as_ushort);
+}
+
+char ini_getval_char(struct INIFILE *ini, char *section_name, char *key, int *state) {
+    getval_setup(INIVAL_TYPE_CHAR)
+    getval_returns(as_char);
+}
+
+unsigned char ini_getval_uchar(struct INIFILE *ini, char *section_name, char *key, int *state) {
+    getval_setup(INIVAL_TYPE_UCHAR)
+    getval_returns(as_uchar);
+}
+
+char *ini_getval_char_p(struct INIFILE *ini, char *section_name, char *key, int *state) {
+    getval_setup(INIVAL_TYPE_STR)
+    getval_returns(as_char_p);
+}
+
+char *ini_getval_str(struct INIFILE *ini, char *section_name, char *key, int *state) {
+    return ini_getval_char_p(ini, section_name, key, state);
+}
+
+char **ini_getval_char_array_p(struct INIFILE *ini, char *section_name, char *key, int *state) {
+    getval_setup(INIVAL_TYPE_STR_ARRAY)
+    getval_returns(as_char_array_p);
+}
+
+char **ini_getval_str_array(struct INIFILE *ini, char *section_name, char *key, int *state) {
+    return ini_getval_char_array_p(ini, section_name, key, state);
+}
+
+struct StrList *ini_getval_strlist(struct INIFILE *ini, char *section_name, char *key, char *tok, int *state) {
+    getval_setup(INIVAL_TYPE_STR_ARRAY)
+    struct StrList *list;
+    list = strlist_init();
+    strlist_append_tokenize(list, result.as_char_p, tok);
+    guard_free(result.as_char_p);
+    return list;
 }
 
 int ini_data_append(struct INIFILE **ini, char *section_name, char *key, char *value) {

--- a/src/ini.c
+++ b/src/ini.c
@@ -122,6 +122,14 @@ int ini_getval(struct INIFILE *ini, char *section_name, char *key, int type, uni
         result->as_char_p = NULL;
         return -1;
     }
+
+    char *render = tpl_render(data->value);
+    if (render) {
+        guard_free(data->value);
+        data->value = render;
+    }
+    lstrip(data->value);
+
     switch (type) {
         case INIVAL_TYPE_CHAR:
             result->as_char = (char) strtol(data->value, NULL, 10);

--- a/tests/test_utils.c
+++ b/tests/test_utils.c
@@ -71,6 +71,7 @@ void test_fix_tox_conf() {
 
     char **lines = file_readlines(result, 0, 0, NULL);
     STASIS_ASSERT(strstr_array(lines, expected) != NULL, "{posargs} not found in result");
+    GENERIC_ARRAY_FREE(lines);
 
     remove(result);
     guard_free(result);
@@ -106,6 +107,7 @@ void test_xml_pretty_print_in_place() {
         STASIS_ASSERT(false, "failed to consume formatted xml file contents");
     }
     STASIS_ASSERT(strcmp(expected, buf) == 0, "xml file was not reformatted");
+    fclose(fp);
 }
 
 void test_path_store() {


### PR DESCRIPTION
The purpose of this PR is to discontinue reading/writing raw pointers in the `INIFILE` structure. This implements the API calls required to interact with the data properly.

`ini_getval()` now returns a copy of the value. If a maintainer wants to modify a value stored in the `INIFILE` structure they should rely on `ini_setval()` to do so.

Original issue I was trying to address:

`ini_write()` did not preserve list indentation correctly. This turned out to be a side-effect related to how data was being written back, in some cases, to the original pointers in the `INIFILE`. I came to the conclusion the only way to preserve the input formatting was to modify those pointers in a more controlled manner, accounting for changes to the format whenever its required.