### PR TITLE
indexer: Handle destination directories more gracefully

### DIFF
--- a/tests/rt_generic.sh
+++ b/tests/rt_generic.sh
@@ -69,6 +69,7 @@ pushd "$ws"
     logfile="stasis_indexer.log"
     set -x
     stasis_indexer --web --unbuffered -v stasis/* 2>&1 | tee "$logfile"
+    retcode=$?
 
     set +x
     find output
@@ -79,7 +80,6 @@ pushd "$ws"
             exit 1
         fi
     done
-
 popd
 
 rm -rf "$ws"


### PR DESCRIPTION
* The indexer now checks whether the source directory provides an `output` directory. If the `output` directory is present, it uses it, else it tries to use the source directory as-is. The problem was, the deployed directory structure _is_ the contents of the `output` directory. If you indexed a local delivery tree it'd work, but if you copied a tree from another source it wouldn't. This should finally handle both cases.
* The `storage.output_dir` is now the `storage.root` to avoid generating a sub-directory beneath the temporary working directory
* The destination directory is created, then resolved by `realpath` to avoid generating the destination directory within the temporary working directory when a relative path is used as input