### PR TITLE
Add template convience functions (and bug fixes)

### DIFF
--- a/include/template_func_proto.h
+++ b/include/template_func_proto.h
@@ -5,5 +5,7 @@
 
 int get_github_release_notes_tplfunc_entrypoint(void *frame, void *data_out);
 int get_github_release_notes_auto_tplfunc_entrypoint(void *frame, void *data_out);
+int get_junitxml_result_auto_entrypoint(void *frame, void *data_out);
+int get_basetemp_result_auto_entrypoint(void *frame, void *data_out);
 
 #endif //TEMPLATE_FUNC_PROTO_H

--- a/include/template_func_proto.h
+++ b/include/template_func_proto.h
@@ -5,7 +5,7 @@
 
 int get_github_release_notes_tplfunc_entrypoint(void *frame, void *data_out);
 int get_github_release_notes_auto_tplfunc_entrypoint(void *frame, void *data_out);
-int get_junitxml_result_auto_entrypoint(void *frame, void *data_out);
-int get_basetemp_result_auto_entrypoint(void *frame, void *data_out);
+int get_junitxml_file_entrypoint(void *frame, void *data_out);
+int get_basetemp_dir_entrypoint(void *frame, void *data_out);
 
 #endif //TEMPLATE_FUNC_PROTO_H

--- a/src/delivery.c
+++ b/src/delivery.c
@@ -1771,6 +1771,9 @@ void delivery_tests_run(struct Delivery *ctx) {
                         cmd[strlen(cmd_rendered) ? strlen(cmd_rendered) - 1 : 0] = 0;
                     }
                     guard_free(cmd_rendered);
+                } else {
+                    SYSERROR("An error occurred while rendering the following:\n%s", cmd);
+                    exit(1);
                 }
 
                 FILE *runner_fp;

--- a/src/delivery.c
+++ b/src/delivery.c
@@ -560,7 +560,7 @@ static int populate_delivery_ini(struct Delivery *ctx, int render_mode) {
 
             test->version = ini_getval_str(ini, section_name, "version", render_mode, &err);
             test->repository = ini_getval_str(ini, section_name, "repository", render_mode, &err);
-            test->script = ini_getval_str(ini, section_name, "script", render_mode, &err);
+            test->script = ini_getval_str(ini, section_name, "script", INI_READ_RAW, &err);
             test->repository_remove_tags = ini_getval_strlist(ini, section_name, "repository_remove_tags", LINE_SEP, render_mode, &err);
             test->build_recipe = ini_getval_str(ini, section_name, "build_recipe", render_mode, &err);
             test->runtime.environ = ini_getval_strlist(ini, section_name, "runtime", LINE_SEP, render_mode, &err);

--- a/src/ini.c
+++ b/src/ini.c
@@ -451,6 +451,11 @@ int ini_write(struct INIFILE *ini, FILE **stream, unsigned mode) {
                         render = parts[p];
                     }
 
+                    if (!render) {
+                        SYSERROR("%s", "rendered string value can never be NULL!\n");
+                        return -1;
+                    }
+
                     if (*hint == INIVAL_TYPE_STR_ARRAY) {
                         int leading_space = isspace(*render);
                         if (leading_space) {

--- a/src/stasis_main.c
+++ b/src/stasis_main.c
@@ -328,6 +328,8 @@ int main(int argc, char *argv[]) {
     // Prototypes can be found in template_func_proto.h
     tpl_register_func("get_github_release_notes", &get_github_release_notes_tplfunc_entrypoint, 3, NULL);
     tpl_register_func("get_github_release_notes_auto", &get_github_release_notes_auto_tplfunc_entrypoint, 1, &ctx);
+    tpl_register_func("get_junitxml_result_auto", &get_junitxml_result_auto_entrypoint, 1, &ctx);
+    tpl_register_func("get_basetemp_result_auto", &get_basetemp_result_auto_entrypoint, 1, &ctx);
 
     // Set up PREFIX/etc directory information
     // The user may manipulate the base directory path with STASIS_SYSCONFDIR

--- a/src/stasis_main.c
+++ b/src/stasis_main.c
@@ -328,8 +328,8 @@ int main(int argc, char *argv[]) {
     // Prototypes can be found in template_func_proto.h
     tpl_register_func("get_github_release_notes", &get_github_release_notes_tplfunc_entrypoint, 3, NULL);
     tpl_register_func("get_github_release_notes_auto", &get_github_release_notes_auto_tplfunc_entrypoint, 1, &ctx);
-    tpl_register_func("get_junitxml_result_auto", &get_junitxml_result_auto_entrypoint, 1, &ctx);
-    tpl_register_func("get_basetemp_result_auto", &get_basetemp_result_auto_entrypoint, 1, &ctx);
+    tpl_register_func("junitxml_file", &get_junitxml_file_entrypoint, 1, &ctx);
+    tpl_register_func("basetemp_dir", &get_basetemp_dir_entrypoint, 1, &ctx);
 
     // Set up PREFIX/etc directory information
     // The user may manipulate the base directory path with STASIS_SYSCONFDIR

--- a/src/template_func_proto.c
+++ b/src/template_func_proto.c
@@ -66,3 +66,47 @@ int get_github_release_notes_auto_tplfunc_entrypoint(void *frame, void *data_out
 
     return result;
 }
+
+int get_junitxml_result_auto_entrypoint(void *frame, void *data_out) {
+    int result = 0;
+    char **output = (char **) data_out;
+    struct tplfunc_frame *f = (struct tplfunc_frame *) frame;
+    const struct Delivery *ctx = (const struct Delivery *) f->data_in;
+
+    char cwd[PATH_MAX] = {0};
+    getcwd(cwd, PATH_MAX - 1);
+    char nametmp[PATH_MAX] = {0};
+    strcpy(nametmp, cwd);
+    char *name = path_basename(nametmp);
+
+    *output = calloc(PATH_MAX, sizeof(**output));
+    if (!*output) {
+        SYSERROR("failed to allocate output string: %s", strerror(errno));
+        return -1;
+    }
+    sprintf(*output, "%s/results-%s-%s.xml", ctx->storage.results_dir, name, ctx->info.release_name);
+
+    return result;
+}
+
+int get_basetemp_result_auto_entrypoint(void *frame, void *data_out) {
+    int result = 0;
+    char **output = (char **) data_out;
+    struct tplfunc_frame *f = (struct tplfunc_frame *) frame;
+    const struct Delivery *ctx = (const struct Delivery *) f->data_in;
+
+    char cwd[PATH_MAX] = {0};
+    getcwd(cwd, PATH_MAX - 1);
+    char nametmp[PATH_MAX] = {0};
+    strcpy(nametmp, cwd);
+    char *name = path_basename(nametmp);
+
+    *output = calloc(PATH_MAX, sizeof(**output));
+    if (!*output) {
+        SYSERROR("failed to allocate output string: %s", strerror(errno));
+        return -1;
+    }
+    sprintf(*output, "%s/truth-%s-%s", ctx->storage.tmpdir, name, ctx->info.release_name);
+
+    return result;
+}

--- a/src/template_func_proto.c
+++ b/src/template_func_proto.c
@@ -67,7 +67,7 @@ int get_github_release_notes_auto_tplfunc_entrypoint(void *frame, void *data_out
     return result;
 }
 
-int get_junitxml_result_auto_entrypoint(void *frame, void *data_out) {
+int get_junitxml_file_entrypoint(void *frame, void *data_out) {
     int result = 0;
     char **output = (char **) data_out;
     struct tplfunc_frame *f = (struct tplfunc_frame *) frame;
@@ -89,7 +89,7 @@ int get_junitxml_result_auto_entrypoint(void *frame, void *data_out) {
     return result;
 }
 
-int get_basetemp_result_auto_entrypoint(void *frame, void *data_out) {
+int get_basetemp_dir_entrypoint(void *frame, void *data_out) {
     int result = 0;
     char **output = (char **) data_out;
     struct tplfunc_frame *f = (struct tplfunc_frame *) frame;

--- a/stasis.ini
+++ b/stasis.ini
@@ -16,7 +16,6 @@ conda_fresh_start = true
 
 ; (list) Conda packages to be installed/overridden in the base environment
 conda_packages =
-    conda>=23.7.0
     conda-build>=3.22.0
     boa
     conda-verify


### PR DESCRIPTION
This PR adds a couple convenience functions to reduce the number of template strings in the delivery config file.

- `{{ func:junitxml_file() }}` - takes no arguments, and returns the absolute file path to the `results-[metadata].xml` file for a given test context
- `{{ func:basetemp_dir() }}` - takes no arguments, and returns the absolute directory path to the delivery context's temporary storage location for pytests (e.g. `$TMPDIR/truth-[metadata]/`)

Bug fixes:

- Report rendering errors and end the program. Syntax errors and such must be corrected before proceeding.
- Test scripts were rendered prematurely. Now they are rendered just prior to execution to help ensure the runtime environment and template variables are fully populated.
- Remove conda `>=` pin in `stasis.ini`. A broken conda release got picked up and helped me lose an hour of my life trying to figure out what was going on. In other words, we'll just use the version of conda bundled with the installer to avoid undefined behavior.