### PR TITLE
Undo changes made to Dockerfile.in templates

### DIFF
--- a/mission/generic/Dockerfile.in
+++ b/mission/generic/Dockerfile.in
@@ -61,8 +61,7 @@ RUN curl -q -OSsL ${DIST_URL}/${DIST_INSTALLER} \
 ENV PATH="${DIST_PATH}/bin:${PATH}"
 # Get delivery snapshot
 ADD ${SNAPSHOT_INPUT} ${HOME}/SNAPSHOT.yml
-ADD ${SNAPSHOT_PKGDIR}/conda ${HOME}/packages/conda
-ADD ${SNAPSHOT_PKGDIR}/wheels ${HOME}/packages/wheels
+ADD ${SNAPSHOT_PKGDIR} ${HOME}/packages
 RUN chown -R developer: ${HOME}
 USER developer
 RUN conda config --set auto_update_conda false \

--- a/mission/hst/Dockerfile.in
+++ b/mission/hst/Dockerfile.in
@@ -61,8 +61,7 @@ RUN curl -q -OSsL ${DIST_URL}/${DIST_INSTALLER} \
 ENV PATH="${DIST_PATH}/bin:${PATH}"
 # Get delivery snapshot
 ADD ${SNAPSHOT_INPUT} ${HOME}/SNAPSHOT.yml
-ADD ${SNAPSHOT_PKGDIR}/conda ${HOME}/packages/conda
-ADD ${SNAPSHOT_PKGDIR}/wheels ${HOME}/packages/wheels
+ADD ${SNAPSHOT_PKGDIR} ${HOME}/packages
 RUN chown -R developer: ${HOME}
 USER developer
 RUN conda config --set auto_update_conda false \

--- a/mission/jwst/Dockerfile.in
+++ b/mission/jwst/Dockerfile.in
@@ -61,8 +61,7 @@ RUN curl -q -OSsL ${DIST_URL}/${DIST_INSTALLER} \
 ENV PATH="${DIST_PATH}/bin:${PATH}"
 # Get delivery snapshot
 ADD ${SNAPSHOT_INPUT} ${HOME}/SNAPSHOT.yml
-ADD ${SNAPSHOT_PKGDIR}/conda ${HOME}/packages/conda
-ADD ${SNAPSHOT_PKGDIR}/wheels ${HOME}/packages/wheels
+ADD ${SNAPSHOT_PKGDIR} ${HOME}/packages
 RUN chown -R developer: ${HOME}
 USER developer
 RUN conda config --set auto_update_conda false \

--- a/mission/roman/Dockerfile.in
+++ b/mission/roman/Dockerfile.in
@@ -61,8 +61,7 @@ RUN curl -q -OSsL ${DIST_URL}/${DIST_INSTALLER} \
 ENV PATH="${DIST_PATH}/bin:${PATH}"
 # Get delivery snapshot
 ADD ${SNAPSHOT_INPUT} ${HOME}/SNAPSHOT.yml
-ADD ${SNAPSHOT_PKGDIR}/conda ${HOME}/packages/conda
-ADD ${SNAPSHOT_PKGDIR}/wheels ${HOME}/packages/wheels
+ADD ${SNAPSHOT_PKGDIR} ${HOME}/packages
 RUN chown -R developer: ${HOME}
 USER developer
 RUN conda config --set auto_update_conda false \


### PR DESCRIPTION
* The packages directory is copied to the build/docker directory. The `docker` directory is not included like I previously thought.
* There is no need to separate these ADD calls.