### PR TITLE
Allow the user to disable uploading build info objects to artifactory

### DIFF
--- a/include/core.h
+++ b/include/core.h
@@ -67,6 +67,7 @@ struct STASIS_GLOBAL {
     bool conda_fresh_start; //!< Always install a new copy of Conda
     bool enable_docker; //!< Enable docker image builds
     bool enable_artifactory; //!< Enable artifactory uploads
+    bool enable_artifactory_build_info; //!< Enable build info (best disabled for pure test runs)
     bool enable_testing; //!< Enable package testing
     bool enable_overwrite; //!< Enable release file clobbering
     bool enable_rewrite_spec_stage_2; //!< Enable automatic @STR@ replacement in output files

--- a/src/delivery.c
+++ b/src/delivery.c
@@ -1927,9 +1927,15 @@ int delivery_artifact_upload(struct Delivery *ctx) {
         }
     }
 
-    if (!status && ctx->deploy.jfrog[0].files && ctx->deploy.jfrog[0].dest) {
-        jfrog_cli_rt_build_collect_env(&ctx->deploy.jfrog_auth, ctx->deploy.jfrog[0].upload_ctx.build_name, ctx->deploy.jfrog[0].upload_ctx.build_number);
-        jfrog_cli_rt_build_publish(&ctx->deploy.jfrog_auth, ctx->deploy.jfrog[0].upload_ctx.build_name, ctx->deploy.jfrog[0].upload_ctx.build_number);
+    if (globals.enable_artifactory_build_info) {
+        if (!status && ctx->deploy.jfrog[0].files && ctx->deploy.jfrog[0].dest) {
+            jfrog_cli_rt_build_collect_env(&ctx->deploy.jfrog_auth, ctx->deploy.jfrog[0].upload_ctx.build_name,
+                                           ctx->deploy.jfrog[0].upload_ctx.build_number);
+            jfrog_cli_rt_build_publish(&ctx->deploy.jfrog_auth, ctx->deploy.jfrog[0].upload_ctx.build_name,
+                                       ctx->deploy.jfrog[0].upload_ctx.build_number);
+        }
+    } else {
+        msg(STASIS_MSG_WARN | STASIS_MSG_L2, "Artifactory build info upload is disabled by CLI argument\n");
     }
 
     return status;

--- a/src/globals.c
+++ b/src/globals.c
@@ -35,6 +35,7 @@ struct STASIS_GLOBAL globals = {
         .tmpdir = NULL,
         .enable_docker = true,
         .enable_artifactory = true,
+        .enable_artifactory_build_info = true,
         .enable_testing = true,
         .enable_rewrite_spec_stage_2 = true,
 };

--- a/src/stasis_main.c
+++ b/src/stasis_main.c
@@ -8,9 +8,10 @@
 #define OPT_ALWAYS_UPDATE_BASE 1000
 #define OPT_NO_DOCKER 1001
 #define OPT_NO_ARTIFACTORY 1002
-#define OPT_NO_TESTING 1003
-#define OPT_OVERWRITE 1004
-#define OPT_NO_REWRITE_SPEC_STAGE_2 1005
+#define OPT_NO_ARTIFACTORY_BUILD_INFO 1003
+#define OPT_NO_TESTING 1004
+#define OPT_OVERWRITE 1005
+#define OPT_NO_REWRITE_SPEC_STAGE_2 1006
 static struct option long_options[] = {
         {"help", no_argument, 0, 'h'},
         {"version", no_argument, 0, 'V'},
@@ -23,6 +24,7 @@ static struct option long_options[] = {
         {"overwrite", no_argument, 0, OPT_OVERWRITE},
         {"no-docker", no_argument, 0, OPT_NO_DOCKER},
         {"no-artifactory", no_argument, 0, OPT_NO_ARTIFACTORY},
+        {"no-artifactory-build-info", no_argument, 0, OPT_NO_ARTIFACTORY_BUILD_INFO},
         {"no-testing", no_argument, 0, OPT_NO_TESTING},
         {"no-rewrite", no_argument, 0, OPT_NO_REWRITE_SPEC_STAGE_2},
         {0, 0, 0, 0},
@@ -40,6 +42,7 @@ const char *long_options_help[] = {
         "Overwrite an existing release",
         "Do not build docker images",
         "Do not upload artifacts to Artifactory",
+        "Do not upload build info objects to Artifactory",
         "Do not execute test scripts",
         "Do not rewrite paths and URLs in output files",
         NULL,
@@ -260,6 +263,9 @@ int main(int argc, char *argv[]) {
                 break;
             case OPT_NO_ARTIFACTORY:
                 globals.enable_artifactory = false;
+                break;
+            case OPT_NO_ARTIFACTORY_BUILD_INFO:
+                globals.enable_artifactory_build_info = false;
                 break;
             case OPT_NO_TESTING:
                 globals.enable_testing = false;


### PR DESCRIPTION
* Add enable_artifactory_build_info to globals structure
* Add --no-artifactory-build-info command line argument
* Useful for diag/test runs when a fully traceable delivery isn't desired