### PR TITLE
BUG: Order matters

### DIFF
--- a/src/cli/stasis/stasis_main.c
+++ b/src/cli/stasis/stasis_main.c
@@ -241,10 +241,10 @@ int main(int argc, char *argv[]) {
 
     msg(STASIS_MSG_L2, "Installing: %s\n", ctx.conda.installer_name);
     delivery_install_conda(ctx.conda.installer_path, ctx.storage.conda_install_prefix);
+    check_pathvar(&ctx);
 
     msg(STASIS_MSG_L2, "Configuring: %s\n", ctx.storage.conda_install_prefix);
     delivery_conda_enable(&ctx, ctx.storage.conda_install_prefix);
-    check_pathvar(&ctx);
 
     //
     // Implied environment creation modes/actions

--- a/src/lib/core/conda.c
+++ b/src/lib/core/conda.c
@@ -218,13 +218,11 @@ int conda_activate(const char *root, const char *env_name) {
     const char *init_script_mamba = "/etc/profile.d/mamba.sh";
     char path_conda[PATH_MAX] = {0};
     char path_mamba[PATH_MAX] = {0};
-    char path_bin[PATH_MAX] = {0};
     char logfile[PATH_MAX] = {0};
     struct Process proc;
     memset(&proc, 0, sizeof(proc));
 
     // Where to find conda's init scripts
-    sprintf(path_bin, "%s/bin", root);
     sprintf(path_conda, "%s%s", root, init_script_conda);
     sprintf(path_mamba, "%s%s", root, init_script_mamba);
 
@@ -258,7 +256,7 @@ int conda_activate(const char *root, const char *env_name) {
 
     // Fully activate conda and record its effect on the runtime environment
     char command[PATH_MAX * 3];
-    snprintf(command, sizeof(command) - 1, "set -a; source %s; source %s; PATH=\"%s:$PATH\" conda activate %s &>/dev/null; env -0", path_conda, path_mamba, path_bin, env_name);
+    snprintf(command, sizeof(command) - 1, "set -a; source %s; source %s; conda activate %s &>/dev/null; env -0", path_conda, path_mamba, env_name);
     int retval = shell(&proc, command);
     if (retval) {
         // it didn't work; drop out for cleanup


### PR DESCRIPTION
Fixes a regression. Originally `PATH` was set to point to the conda installation directory *before* trying to enable it. At some point this changed, and I ended up writing a workaround.

This reverts the changes to `conda_activate` that were made a couple PRs ago.