### PR TITLE
Fix git_clone return

### DIFF
--- a/src/lib/core/utils.c
+++ b/src/lib/core/utils.c
@@ -331,7 +331,7 @@ int git_clone(struct Process *proc, char *url, char *destdir, char *gitref) {
     {
         memset(command, 0, sizeof(command));
         sprintf(command, "%s fetch --all", program);
-        result += shell(proc, command);
+        result = shell(proc, command);
 
         if (gitref != NULL) {
             memset(command, 0, sizeof(command));

--- a/src/lib/core/utils.c
+++ b/src/lib/core/utils.c
@@ -307,39 +307,64 @@ int touch(const char *filename) {
 }
 
 int git_clone(struct Process *proc, char *url, char *destdir, char *gitref) {
-    int result = -1;
+    int result = 0;
     char *chdir_to = NULL;
     char *program = find_program("git");
     if (!program) {
-        return result;
+        result = -1;
+        goto die_quick;
     }
 
-    static char command[PATH_MAX];
+    static char command[PATH_MAX] = {0};
     sprintf(command, "%s clone -c advice.detachedHead=false --recursive %s", program, url);
+
     if (destdir && access(destdir, F_OK) < 0) {
+        // Destination directory does not exist
         sprintf(command + strlen(command), " %s", destdir);
+        // Clone the repo
         result = shell(proc, command);
+        if (result) {
+            goto die_quick;
+        }
     }
 
     if (destdir) {
         chdir_to = destdir;
     } else {
+        // Assume the name of the directory to be the basename of the URL
+        // like it is when executed in a shell session
         chdir_to = path_basename(url);
     }
 
-    pushd(chdir_to);
-    {
+    if (!pushd(chdir_to)) {
         memset(command, 0, sizeof(command));
         sprintf(command, "%s fetch --all", program);
         result = shell(proc, command);
+        if (result) {
+            goto die_pop;
+        }
 
         if (gitref != NULL) {
             memset(command, 0, sizeof(command));
             sprintf(command, "%s checkout %s", program, gitref);
-            result += shell(proc, command);
+
+            result = shell(proc, command);
+            if (result) {
+                goto die_pop;
+            }
         }
         popd();
+    } else {
+        result = -1;
+        goto die_quick;
     }
+    return 0;
+
+    die_pop:
+    // close out last pushd() call
+    popd();
+
+    die_quick:
     return result;
 }
 

--- a/src/lib/delivery/delivery_build.c
+++ b/src/lib/delivery/delivery_build.c
@@ -154,7 +154,11 @@ struct StrList *delivery_build_wheels(struct Delivery *ctx) {
                 memset(wheeldir, 0, sizeof(wheeldir));
 
                 sprintf(srcdir, "%s/%s", ctx->storage.build_sources_dir, ctx->tests[i].name);
-                git_clone(&proc, ctx->tests[i].repository, srcdir, ctx->tests[i].version);
+                if (git_clone(&proc, ctx->tests[i].repository, srcdir, ctx->tests[i].version)) {
+                    SYSERROR("Unable to checkout tag '%s' for package '%s' from repository '%s'\n",
+                    ctx->tests[i].version, ctx->tests[i].name, ctx->tests[i].repository);
+                    return NULL;
+                }
 
                 if (ctx->tests[i].repository_remove_tags && strlist_count(ctx->tests[i].repository_remove_tags)) {
                     filter_repo_tags(srcdir, ctx->tests[i].repository_remove_tags);

--- a/tests/test_recipe.c
+++ b/tests/test_recipe.c
@@ -94,8 +94,6 @@ int main(int argc, char *argv[]) {
     STASIS_TEST_FUNC *tests[] = {
         test_recipe_clone,
     };
-    mkdir("workspace", 0755);
-    pushd("workspace");
     STASIS_TEST_RUN(tests);
     popd();
     STASIS_TEST_END_MAIN();


### PR DESCRIPTION
Also fixes the case where cloning fell through on failure in `delivery_build_wheels` leading to unexpected errors later on