### PR TITLE
Allow removing packages from a delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,15 +246,17 @@ All configuration section names and keys are _case-sensitive_.
 
 ### conda
 
-| Key                | Type   | Purpose                    | Required |
-|--------------------|--------|----------------------------|----------|
-| installer_name     | String | Conda distribution name    | Y        |
-| installer_version  | String | Conda distribution version | Y        |
-| installer_platform | String | Conda target platform      | Y        |
-| installer_arch     | String | Conda target architecture  | Y        |
-| installer_baseurl  | String | Conda installer URL        | Y        |
-| conda_packages     | List   | Conda packages to install  | N        |
-| pip_packages       | List   | Pypi packages to install   | N        |
+| Key                  | Type   | Purpose                    | Required |
+|----------------------|--------|----------------------------|----------|
+| installer_name       | String | Conda distribution name    | Y        |
+| installer_version    | String | Conda distribution version | Y        |
+| installer_platform   | String | Conda target platform      | Y        |
+| installer_arch       | String | Conda target architecture  | Y        |
+| installer_baseurl    | String | Conda installer URL        | Y        |
+| conda_packages       | List   | Conda packages to install  | N        |
+| conda_packages_purge | List   | Conda packages to remove   | N        |
+| pip_packages         | List   | Pypi packages to install   | N        |
+| pip_packages_purge   | List   | Conda packages to remove   | N        |
 
 ### runtime
 

--- a/src/cli/stasis/stasis_main.c
+++ b/src/cli/stasis/stasis_main.c
@@ -390,6 +390,20 @@ int main(int argc, char *argv[]) {
     }
 
     if (!isempty(ctx.meta.based_on)) {
+        if (ctx.conda.conda_packages_purge && strlist_count(ctx.conda.conda_packages_purge)) {
+            msg(STASIS_MSG_L2, "Purging conda packages\n");
+            if (delivery_purge_packages(&ctx, env_name_testing, PKG_USE_CONDA)) {
+                msg(STASIS_MSG_ERROR | STASIS_MSG_L2, "unable to purge requested conda packages from %s\n", env_name_testing);
+                exit(1);
+            }
+        }
+        if (ctx.conda.pip_packages_purge && strlist_count(ctx.conda.pip_packages_purge)) {
+            msg(STASIS_MSG_L2, "Purging pip packages\n");
+            if (delivery_purge_packages(&ctx, env_name_testing, PKG_USE_PIP)) {
+                msg(STASIS_MSG_ERROR | STASIS_MSG_L2, "unable to purge requested pip packages from %s\n", env_name_testing);
+                exit(1);
+            }
+        }
         msg(STASIS_MSG_L1, "Generating package overlay from environment: %s\n", env_name);
         if (delivery_overlay_packages_from_env(&ctx, env_name)) {
             msg(STASIS_MSG_L2 | STASIS_MSG_ERROR, "%s", "Failed to generate package overlay. Resulting environment integrity cannot be guaranteed.\n");
@@ -460,6 +474,22 @@ int main(int argc, char *argv[]) {
         }
     } else {
         msg(STASIS_MSG_L3, "No deferred conda packages\n");
+    }
+
+    if (ctx.conda.conda_packages_purge && strlist_count(ctx.conda.conda_packages_purge)) {
+        msg(STASIS_MSG_L2, "Purging conda packages\n");
+        if (delivery_purge_packages(&ctx, env_name, PKG_USE_CONDA)) {
+            msg(STASIS_MSG_ERROR | STASIS_MSG_L2, "unable to purge requested conda packages\n");
+            exit(1);
+        }
+    }
+
+    if (ctx.conda.pip_packages_purge && strlist_count(ctx.conda.pip_packages_purge)) {
+        msg(STASIS_MSG_L2, "Purging pip packages\n");
+        if (delivery_purge_packages(&ctx, env_name, PKG_USE_PIP)) {
+            msg(STASIS_MSG_ERROR | STASIS_MSG_L2, "unable to purge requested pip packages");
+            exit(1);
+        }
     }
 
     msg(STASIS_MSG_L2, "Installing pip packages\n");

--- a/src/lib/delivery/delivery_populate.c
+++ b/src/lib/delivery/delivery_populate.c
@@ -150,11 +150,13 @@ int populate_delivery_ini(struct Delivery *ctx, int render_mode) {
     ctx->conda.installer_arch = ini_getval_str(ini, "conda", "installer_arch", render_mode, &err);
     ctx->conda.installer_baseurl = ini_getval_str(ini, "conda", "installer_baseurl", render_mode, &err);
     ctx->conda.conda_packages = ini_getval_strlist(ini, "conda", "conda_packages", LINE_SEP, render_mode, &err);
-    ctx->conda.pip_packages = ini_getval_strlist(ini, "conda", "pip_packages", LINE_SEP, render_mode, &err);
-
     normalize_ini_list(&ini, &ctx->conda.conda_packages, "conda", "conda_packages", render_mode);
+    ctx->conda.conda_packages_purge = ini_getval_strlist(ini, "conda", "conda_packages_purge", LINE_SEP, render_mode, &err);
+    normalize_ini_list(&ini, &ctx->conda.conda_packages_purge, "conda", "conda_package_purge", render_mode);
+    ctx->conda.pip_packages = ini_getval_strlist(ini, "conda", "pip_packages", LINE_SEP, render_mode, &err);
     normalize_ini_list(&ini, &ctx->conda.pip_packages, "conda", "pip_packages", render_mode);
-
+    ctx->conda.pip_packages_purge = ini_getval_strlist(ini, "conda", "pip_packages_purge", LINE_SEP, render_mode, &err);
+    normalize_ini_list(&ini, &ctx->conda.pip_packages_purge, "conda", "pip_packages_purge", render_mode);
 
     // Delivery metadata consumed
     populate_mission_ini(&ctx, render_mode);

--- a/src/lib/delivery/include/delivery.h
+++ b/src/lib/delivery/include/delivery.h
@@ -141,8 +141,10 @@ struct Delivery {
         char *tool_build_version;               ///< Installed version of "build" package
         struct StrList *conda_packages;         ///< Conda packages to deliver
         struct StrList *conda_packages_defer;   ///< Conda recipes to be built for delivery
+        struct StrList *conda_packages_purge;   ///< Conda packages to remove from a delivery (for: based_on)
         struct StrList *pip_packages;           ///< Python packages to install (pip)
         struct StrList *pip_packages_defer;     ///< Python packages to be built for delivery
+        struct StrList *pip_packages_purge;     ///< Python packages to remove from a delivery (for: based_on)
         struct StrList *wheels_packages;        ///< Wheel packages built for delivery
     } conda;
 
@@ -444,5 +446,17 @@ int delivery_overlay_packages_from_env(struct Delivery *ctx, const char *env_nam
  * @return 0 on success
  */
 int delivery_series_sync(struct Delivery *ctx);
+
+/**
+ * Remove packages from an environment
+ * @param ctx Delivery context
+ * @param env_name Name of conda environment
+ * @param use_pkg_manager PKG_USE_PIP
+ * @param use_pkg_manager PKG_USE_CONDA
+ * @returns -1 on error
+ * @returns 0 on success
+ * @returns >0 on failure
+ */
+int delivery_purge_packages(struct Delivery *ctx, const char *env_name, int use_pkg_manager);
 
 #endif //STASIS_DELIVERY_H


### PR DESCRIPTION
Use case:

```yaml
dependencies:
  - python
  - a
  - b
  - c
  - pip:
    - d
    - e
    - f
```

```ini
[meta]
based_on = https://some/previous/delivery.yml

[conda]
conda_packages_purge =
    b
pip_packages_purge =
    e
```

Result:

1. `based_on` installs the contents of delivery.yml
2. `*_purge` removes packages `b` and `e` from the environment
3. The new delivery will not provide packages `b` and `e`.