### PR TITLE
Indexer: Fix garbage in file path

### DIFF
--- a/src/cli/stasis_indexer/helpers.c
+++ b/src/cli/stasis_indexer/helpers.c
@@ -35,6 +35,7 @@ int get_pandoc_version(size_t *result) {
     char *version_str = shell_output("pandoc --version", &state);
     if (state || !version_str) {
         // an error occurred
+        guard_free(version_str);
         return -1;
     }
 
@@ -44,6 +45,7 @@ int get_pandoc_version(size_t *result) {
         char *v_begin = &version_str[7];
         if (!v_begin) {
             SYSERROR("unexpected pandoc output: %s", version_str);
+            guard_free(version_str);
             return -1;
         }
         char *v_end = strchr(version_str, '\n');
@@ -54,6 +56,7 @@ int get_pandoc_version(size_t *result) {
         char **parts = split(v_begin, ".", 0);
         if (!parts) {
             SYSERROR("unable to split pandoc version string, '%s': %s", version_str, strerror(errno));
+            guard_free(version_str);
             return -1;
         }
 
@@ -71,11 +74,14 @@ int get_pandoc_version(size_t *result) {
             // pack version element into result
             *result = *result << 8 | tmp;
         }
+        GENERIC_ARRAY_FREE(parts);
     } else {
         // invalid version string
+        guard_free(version_str);
         return 1;
     }
 
+    guard_free(version_str);
     return 0;
 }
 

--- a/src/cli/stasis_indexer/junitxml_report.c
+++ b/src/cli/stasis_indexer/junitxml_report.c
@@ -139,8 +139,10 @@ int indexer_junitxml_report(struct Delivery ctx[], const size_t nelem) {
         popd();
     } else {
         fprintf(stderr, "Unable to enter delivery directory: %s\n", ctx->storage.delivery_dir);
+        guard_strlist_free(&file_listing);
         return -1;
     }
 
+    guard_strlist_free(&file_listing);
     return 0;
 }

--- a/src/cli/stasis_indexer/junitxml_report.c
+++ b/src/cli/stasis_indexer/junitxml_report.c
@@ -28,7 +28,7 @@ static int write_report_output(struct Delivery *ctx, FILE *destfp, const char *x
         }
 
         char *bname_tmp = strdup(xmlfilename);
-        char *bname = path_basename(bname_tmp);
+        char *bname = strdup(path_basename(bname_tmp));
         if (endswith(bname, ".xml")) {
             bname[strlen(bname) - 4] = 0;
         }
@@ -51,6 +51,8 @@ static int write_report_output(struct Delivery *ctx, FILE *destfp, const char *x
 
         snprintf(result_outfile, sizeof(result_outfile) - strlen(bname) - 3, "%s.md",
                  bname);
+        guard_free(bname);
+
         FILE *resultfp = fopen(result_outfile, "w+");
         if (!resultfp) {
             SYSERROR("Unable to open %s for writing", result_outfile);

--- a/src/cli/stasis_indexer/junitxml_report.c
+++ b/src/cli/stasis_indexer/junitxml_report.c
@@ -105,7 +105,7 @@ int indexer_junitxml_report(struct Delivery ctx[], const size_t nelem) {
             fprintf(stderr, "Unable to open %s for writing\n", indexfile);
             return -1;
         }
-        printf("index %s opened for writing", indexfile);
+        printf("Index %s opened for writing\n", indexfile);
 
         for (size_t d = 0; d < nelem; d++) {
             char pattern[PATH_MAX] = {0};

--- a/src/cli/stasis_indexer/stasis_indexer_main.c
+++ b/src/cli/stasis_indexer/stasis_indexer_main.c
@@ -204,7 +204,7 @@ int main(const int argc, char *argv[]) {
     const int current_index = optind;
     if (optind < argc) {
         rootdirs_total = argc - current_index;
-        rootdirs = calloc(rootdirs_total + 1, sizeof(**rootdirs));
+        rootdirs = calloc(rootdirs_total + 1, sizeof(*rootdirs));
 
         int i = 0;
         while (optind < argc) {
@@ -391,8 +391,12 @@ int main(const int argc, char *argv[]) {
     guard_free(destdir);
     GENERIC_ARRAY_FREE(rootdirs);
     guard_strlist_free(&metafiles);
+    guard_free(m.micromamba_prefix);
     delivery_free(&ctx);
+    guard_free(local);
     globals_free();
+
     msg(STASIS_MSG_L1, "Done!\n");
+
     return 0;
 }


### PR DESCRIPTION
Problem (exploded for clarity):
```
pandoc \
    --embed-resources \
    --standalone \
    -f gfm+autolink_bare_uris -f gfm+alerts \
    --css /runner/_work/datapipeline-workflows/datapipeline-workflows/.local/etc/stasis/stasis_pandoc.css \
    --metadata title="STASIS" \
    -o /tmp/stasis-combine.V8r9zv/results/inux-x86_64stools-ABC-2025.1.1-1+corncob-py311-linux-x86_64.html \
                                          ^^^^^^^^^^^^^^^^^
    /tmp/stasis-combine.V8r9zv/results/inux-x86_64stools-ABC-2025.1.1-1+corncob-py311-linux-x86_64.md
                                       ^^^^^^^^^^^^^^^^^
```