### PR TITLE
Bug fix wheel indexes

### DIFF
--- a/src/lib/delivery/delivery_postprocess.c
+++ b/src/lib/delivery/delivery_postprocess.c
@@ -238,7 +238,7 @@ int delivery_index_wheel_artifacts(struct Delivery *ctx) {
         }
 
         for (size_t i = 0; i < strlist_count(packages); i++) {
-            char *package = strlist_item(packages, i);
+            char *package = path_basename(strlist_item(packages, i));
             if (!endswith(package, ".whl")) {
                 continue;
             }


### PR DESCRIPTION
* This prevents absolute paths returned by listdir() from being injected into the "bottom" index.html file.
* The href target should be relative to the local directory structure, not an absolute path.