### PR TITLE
Enable codenames outside of HST

### DIFF
--- a/src/lib/delivery/delivery_init.c
+++ b/src/lib/delivery/delivery_init.c
@@ -289,10 +289,18 @@ int bootstrap_build_info(struct Delivery *ctx) {
     struct Delivery local = {0};
     local._stasis_ini_fp.cfg = ini_open(ctx->_stasis_ini_fp.cfg_path);
     local._stasis_ini_fp.delivery = ini_open(ctx->_stasis_ini_fp.delivery_path);
-    delivery_init_platform(&local);
-    populate_delivery_cfg(&local, INI_READ_RENDER);
-    populate_delivery_ini(&local, INI_READ_RENDER);
-    populate_info(&local);
+    if (delivery_init_platform(&local)) {
+        return -1;
+    }
+    if (populate_delivery_cfg(&local, INI_READ_RENDER)) {
+        return -1;
+    }
+    if (populate_delivery_ini(&local, INI_READ_RENDER)) {
+        return -1;
+    }
+    if (populate_info(&local)) {
+        return -1;
+    }
     ctx->info.build_name = strdup(local.info.build_name);
     ctx->info.build_number = strdup(local.info.build_number);
     ctx->info.release_name = strdup(local.info.release_name);

--- a/src/lib/delivery/delivery_populate.c
+++ b/src/lib/delivery/delivery_populate.c
@@ -171,13 +171,7 @@ int populate_delivery_ini(struct Delivery *ctx, int render_mode) {
 
     int err = 0;
     ctx->meta.mission = ini_getval_str(ini, "meta", "mission", render_mode, &err);
-
-    if (!strcasecmp(ctx->meta.mission, "hst")) {
-        ctx->meta.codename = ini_getval_str(ini, "meta", "codename", render_mode, &err);
-    } else {
-        ctx->meta.codename = NULL;
-    }
-
+    ctx->meta.codename = ini_getval_str(ini, "meta", "codename", render_mode, &err);
     ctx->meta.version = ini_getval_str(ini, "meta", "version", render_mode, &err);
     ctx->meta.name = ini_getval_str(ini, "meta", "name", render_mode, &err);
     ctx->meta.rc = ini_getval_int(ini, "meta", "rc", render_mode, &err);
@@ -213,6 +207,12 @@ int populate_delivery_ini(struct Delivery *ctx, int render_mode) {
         guard_free(ctx->info.release_name);
         guard_free(ctx->info.build_name);
         guard_free(ctx->info.build_number);
+    }
+
+    // Fail if a mission requires a codename, but one is not defined
+    if (strstr(ctx->rules.release_fmt, "%c") && isempty(ctx->meta.codename)) {
+        SYSERROR("Mission type '%s' requires meta.codename to be defined", ctx->meta.mission);
+        return -1;
     }
 
     if (delivery_format_str(ctx, &ctx->info.release_name, ctx->rules.release_fmt)) {


### PR DESCRIPTION
* Return from the bootstrap function when an error occurs