### PR TITLE
Memory macro behavior

### DIFF
--- a/src/cli/stasis_indexer/helpers.c
+++ b/src/cli/stasis_indexer/helpers.c
@@ -74,7 +74,7 @@ int get_pandoc_version(size_t *result) {
             // pack version element into result
             *result = *result << 8 | tmp;
         }
-        GENERIC_ARRAY_FREE(parts);
+        guard_array_free(parts);
     } else {
         // invalid version string
         guard_free(version_str);
@@ -350,7 +350,7 @@ int load_metadata(struct Delivery *ctx, const char *filename) {
         } else if (!strcmp(name, "conda_installer_arch")) {
             ctx->conda.installer_arch = strdup(value);
         }
-        GENERIC_ARRAY_FREE(parts);
+        guard_array_free(parts);
     }
     fclose(fp);
 

--- a/src/cli/stasis_indexer/stasis_indexer_main.c
+++ b/src/cli/stasis_indexer/stasis_indexer_main.c
@@ -389,7 +389,7 @@ int main(const int argc, char *argv[]) {
     }
 
     guard_free(destdir);
-    GENERIC_ARRAY_FREE(rootdirs);
+    guard_array_free(rootdirs);
     guard_strlist_free(&metafiles);
     guard_free(m.micromamba_prefix);
     delivery_free(&ctx);

--- a/src/lib/core/conda.c
+++ b/src/lib/core/conda.c
@@ -265,7 +265,7 @@ static int env0_to_runtime(const char *logfile) {
         } else {
             setenv(part[0], part[1], 1);
         }
-        GENERIC_ARRAY_FREE(part);
+        guard_array_free(part);
     }
     fclose(fp);
     return 0;

--- a/src/lib/core/docker.c
+++ b/src/lib/core/docker.c
@@ -191,6 +191,6 @@ int docker_validate_compression_program(char *prog) {
     result = find_program(parts[0]) ? 0 : -1;
 
     invalid:
-    GENERIC_ARRAY_FREE(parts);
+    guard_array_free(parts);
     return result;
 }

--- a/src/lib/core/environment.c
+++ b/src/lib/core/environment.c
@@ -117,7 +117,7 @@ void runtime_export(RuntimeEnv *env, char **keys) {
             puts(output);
         }
         guard_free(value);
-        GENERIC_ARRAY_FREE(pair);
+        guard_array_free(pair);
     }
 }
 
@@ -210,10 +210,10 @@ ssize_t runtime_contains(RuntimeEnv *env, const char *key) {
         }
         if (strcmp(pair[0], key) == 0) {
             result = i;
-            GENERIC_ARRAY_FREE(pair);
+            guard_array_free(pair);
             break;
         }
-        GENERIC_ARRAY_FREE(pair);
+        guard_array_free(pair);
     }
     return result;
 }
@@ -246,7 +246,7 @@ char *runtime_get(RuntimeEnv *env, const char *key) {
     if (key_offset != -1) {
         char **pair = split(strlist_item(env, key_offset), "=", 0);
         result = join(&pair[1], "=");
-        GENERIC_ARRAY_FREE(pair);
+        guard_array_free(pair);
     }
     return result;
 }
@@ -425,7 +425,7 @@ void runtime_apply(RuntimeEnv *env) {
     for (size_t i = 0; i < strlist_count(env); i++) {
         char **pair = split(strlist_item(env, i), "=", 1);
         setenv(pair[0], pair[1], 1);
-        GENERIC_ARRAY_FREE(pair);
+        guard_array_free(pair);
     }
 }
 

--- a/src/lib/core/include/core_mem.h
+++ b/src/lib/core/include/core_mem.h
@@ -5,10 +5,17 @@
 #include "environment.h"
 #include "strlist.h"
 
-#define guard_runtime_free(X) do { if (X) { runtime_free(X); (X) = NULL; } } while (0)
-#define guard_strlist_free(X) do { if ((*X)) { strlist_free(X); (*X) = NULL; } } while (0)
-#define guard_free(X) do { if (X) { free(X); X = NULL; } } while (0)
-#define GENERIC_ARRAY_FREE(ARR) do { \
+#define guard_runtime_free(X) do { runtime_free(X); (X) = NULL; } while (0)
+#define guard_strlist_free(X) do { strlist_free(X); (*X) = NULL; } while (0)
+#define guard_free(X) do { free(X); (X) = NULL; } while (0)
+#define ARRAY_COUNT(ARR) sizeof((ARR)) / sizeof((*ARR))
+#define guard_array_free_by_count(ARR, COUNT) do { \
+    for (size_t ARR_I = 0; (ARR) && ARR_I < (COUNT); ARR_I++) { \
+        guard_free((ARR)[ARR_I]); \
+    } \
+    guard_free((ARR)); \
+} while (0)
+#define guard_array_free(ARR) do { \
     for (size_t ARR_I = 0; ARR && ARR[ARR_I] != NULL; ARR_I++) { \
         guard_free(ARR[ARR_I]); \
     } \

--- a/src/lib/core/ini.c
+++ b/src/lib/core/ini.c
@@ -465,7 +465,7 @@ int ini_write(struct INIFILE *ini, FILE **stream, unsigned mode) {
                         guard_free(render);
                     }
                 }
-                GENERIC_ARRAY_FREE(parts);
+                guard_array_free(parts);
                 strip(outvalue);
                 strcat(outvalue, LINE_SEP);
                 fprintf(*stream, "%s = %s%s", ini->section[x]->data[y]->key, *hint == INIVAL_TYPE_STR_ARRAY ? LINE_SEP : "", outvalue);

--- a/src/lib/core/strlist.c
+++ b/src/lib/core/strlist.c
@@ -222,7 +222,7 @@ void strlist_append_strlist(struct StrList *pStrList1, struct StrList *pStrList2
              lstrip(token[i]);
              strlist_append(&pStrList, token[i]);
          }
-         GENERIC_ARRAY_FREE(token);
+         guard_array_free(token);
      }
     guard_free(tmp);
  }

--- a/src/lib/core/template.c
+++ b/src/lib/core/template.c
@@ -275,7 +275,7 @@ char *tpl_render(char *str) {
                     SYSDEBUG("Returned from function: %s (status: %d)\nData OUT\n--------\n'%s'", k, func_status, value);
                     guard_free(func_result);
                 }
-                GENERIC_ARRAY_FREE(params);
+                guard_array_free(params);
             } else {
                 // Read replacement value
                 value = strdup(tpl_getval(key) ? tpl_getval(key) : "");

--- a/src/lib/core/wheel.c
+++ b/src/lib/core/wheel.c
@@ -99,12 +99,12 @@ struct Wheel *get_wheel_info(const char *basepath, const char *name, char *to_ma
         } else {
             SYSERROR("Unknown wheel name format: %s. Expected 5 or 6 strings "
                      "separated by '-', but got %zu instead", filename, parts_total);
-            GENERIC_ARRAY_FREE(parts);
+            guard_array_free(parts);
             wheel_free(&result);
             closedir(dp);
             return NULL;
         }
-        GENERIC_ARRAY_FREE(parts);
+        guard_array_free(parts);
         break;
     }
     closedir(dp);

--- a/src/lib/delivery/delivery.c
+++ b/src/lib/delivery/delivery.c
@@ -2,7 +2,7 @@
 
 void delivery_free(struct Delivery *ctx) {
     guard_free(ctx->system.arch);
-    GENERIC_ARRAY_FREE(ctx->system.platform);
+    guard_array_free(ctx->system.platform);
     guard_free(ctx->meta.name);
     guard_free(ctx->meta.version);
     guard_free(ctx->meta.codename);

--- a/src/lib/delivery/delivery_postprocess.c
+++ b/src/lib/delivery/delivery_postprocess.c
@@ -120,7 +120,7 @@ void delivery_rewrite_spec(struct Delivery *ctx, char *filename, unsigned stage)
             }
             fprintf(tp, "%s", contents[i]);
         }
-        GENERIC_ARRAY_FREE(contents);
+        guard_array_free(contents);
         guard_free(header);
         fflush(tp);
         fclose(tp);

--- a/tests/test_environment.c
+++ b/tests/test_environment.c
@@ -20,7 +20,7 @@ void test_runtime_copy_empty() {
     char **empty_env = calloc(1, sizeof(empty_env));
     RuntimeEnv *env = runtime_copy(empty_env);
     STASIS_ASSERT(env->num_inuse == 0, "copied array isn't empty");
-    GENERIC_ARRAY_FREE(empty_env);
+    guard_array_free(empty_env);
     runtime_free(env);
 }
 

--- a/tests/test_str.c
+++ b/tests/test_str.c
@@ -79,7 +79,7 @@ void test_strdup_array_and_strcmp_array() {
     for (size_t outer = 0; outer < sizeof(tc) / sizeof(*tc); outer++) {
         char **result = strdup_array((char **) tc[outer].data);
         STASIS_ASSERT(strcmp_array((const char **) result, tc[outer].expected) == 0, "array members were different");
-        GENERIC_ARRAY_FREE(result);
+        guard_array_free(result);
     }
 
     const struct testcase tc_bad[] = {
@@ -95,7 +95,7 @@ void test_strdup_array_and_strcmp_array() {
     for (size_t outer = 0; outer < sizeof(tc_bad) / sizeof(*tc_bad); outer++) {
         char **result = strdup_array((char **) tc_bad[outer].data);
         STASIS_ASSERT(strcmp_array((const char **) result, tc_bad[outer].expected) != 0, "array members were identical");
-        GENERIC_ARRAY_FREE(result);
+        guard_array_free(result);
     }
 }
 
@@ -206,7 +206,7 @@ void test_split() {
     for (size_t i = 0; i < sizeof(tc) / sizeof(*tc); i++) {
         char **result = split((char *) tc[i].data, tc[i].delim, tc[i].max_split);
         STASIS_ASSERT(strcmp_array((const char **) result, tc[i].expected) == 0, "Split failed");
-        GENERIC_ARRAY_FREE(result);
+        guard_array_free(result);
     }
 }
 
@@ -289,7 +289,7 @@ void test_strdeldup() {
     for (size_t i = 0; i < sizeof(tc) / sizeof(*tc); i++) {
         char **result = strdeldup(tc[i].data);
         STASIS_ASSERT(strcmp_array((const char **) result, tc[i].expected) == 0, "incorrect number of duplicates removed");
-        GENERIC_ARRAY_FREE(result);
+        guard_array_free(result);
     }
 }
 

--- a/tests/test_utils.c
+++ b/tests/test_utils.c
@@ -72,7 +72,7 @@ void test_fix_tox_conf() {
 
     char **lines = file_readlines(result, 0, 0, NULL);
     STASIS_ASSERT(strstr_array(lines, expected) != NULL, "{posargs} not found in result");
-    GENERIC_ARRAY_FREE(lines);
+    guard_array_free(lines);
 
     remove(result);
     guard_free(result);
@@ -283,15 +283,15 @@ void test_file_readlines() {
     for (i = 0; result[i] != NULL; i++);
     STASIS_ASSERT(num_chars(data, '\n') == i, "incorrect number of lines in data");
     STASIS_ASSERT(strcmp(result[3], "see?\n") == 0, "last line in data is incorrect'");
-    GENERIC_ARRAY_FREE(result);
+    guard_array_free(result);
 
     result = file_readlines(filename, 0, 0, file_readlines_callback_modify);
     STASIS_ASSERT(strcmp(result[3], "xxx?\n") == 0, "last line should be: 'xxx?\\n'");
-    GENERIC_ARRAY_FREE(result);
+    guard_array_free(result);
 
     result = file_readlines(filename, 0, 0, file_readlines_callback_get_specific_line);
     STASIS_ASSERT(strcmp(result[0], "see?\n") == 0, "the first record of the result is not the last line of the file 'see?\\n'");
-    GENERIC_ARRAY_FREE(result);
+    guard_array_free(result);
     remove(filename);
 }
 


### PR DESCRIPTION
`free()` already does nothing when the pointer is `NULL`. Removes needless branches.