### PR TITLE
base and "based_on" installations shall hardcode the requested python…

### DIFF
--- a/src/cli/stasis/stasis_main.c
+++ b/src/cli/stasis/stasis_main.c
@@ -325,9 +325,6 @@ int main(int argc, char *argv[]) {
                 exit(1);
             }
             copy2(mission_base_orig, mission_base, CT_OWNER | CT_PERM);
-            char spec[255] = {0};
-            snprintf(spec, sizeof(spec) - 1, "- python=%s\n", ctx.meta.python);
-            file_replace_text(mission_base, "- python\n", spec, 0);
             ctx.meta.based_on = mission_base;
         }
         guard_free(mission_base_orig);
@@ -340,7 +337,7 @@ int main(int argc, char *argv[]) {
         }
 
         msg(STASIS_MSG_L2, "Based on: %s\n", ctx.meta.based_on);
-        if (conda_env_create_from_uri(env_name, ctx.meta.based_on)) {
+        if (conda_env_create_from_uri(env_name, ctx.meta.based_on, ctx.meta.python)) {
             msg(STASIS_MSG_ERROR | STASIS_MSG_L2, "unable to install release environment using configuration file\n");
             exit(1);
         }
@@ -349,7 +346,7 @@ int main(int argc, char *argv[]) {
             msg(STASIS_MSG_ERROR | STASIS_MSG_L2, "failed to remove testing environment %s\n", env_name_testing);
             exit(1);
         }
-        if (conda_env_create_from_uri(env_name_testing, ctx.meta.based_on)) {
+        if (conda_env_create_from_uri(env_name_testing, ctx.meta.based_on, ctx.meta.python)) {
             msg(STASIS_MSG_ERROR | STASIS_MSG_L2, "unable to install testing environment using configuration file\n");
             exit(1);
         }

--- a/src/lib/core/include/conda.h
+++ b/src/lib/core/include/conda.h
@@ -127,7 +127,7 @@ int conda_setup_headless();
  * @param uri ftp://myserver.tld/environment.yml
  * @return exit code from "conda"
  */
-int conda_env_create_from_uri(char *name, char *uri);
+int conda_env_create_from_uri(char *name, char *uri, char *python_version);
 
 /**
  * Create a Conda environment using generic package specs

--- a/tests/test_conda.c
+++ b/tests/test_conda.c
@@ -111,7 +111,7 @@ void test_conda_setup_headless() {
 void test_conda_env_create_from_uri() {
     const char *url = "https://ssb.stsci.edu/jhunk/stasis_test/test_conda_env_create_from_uri.yml";
     char *name = strdup(__FUNCTION__);
-    STASIS_ASSERT(conda_env_create_from_uri(name, (char *) url) == 0, "creating an environment from a remote source failed");
+    STASIS_ASSERT(conda_env_create_from_uri(name, (char *) url, "3.11") == 0, "creating an environment from a remote source failed");
     free(name);
 }
 


### PR DESCRIPTION
… version in the YAML config instead of trusting it

* This only affects configs with a bare python definition like `- python` (no version)