### PR TITLE
Compare up to the length of the name string, not the package.

### DIFF
--- a/src/lib/delivery/delivery_install.c
+++ b/src/lib/delivery/delivery_install.c
@@ -36,7 +36,7 @@ static char *have_spec_in_config(const struct Delivery *ctx, const char *name) {
             strncpy(package, config_spec, sizeof(package) - 1);
         }
         remove_extras(package);
-        if (strncmp(package, name, strlen(package)) == 0) {
+        if (strncmp(package, name, strlen(name)) == 0) {
             return config_spec;
         }
     }


### PR DESCRIPTION
Resolves the following botched output

```
====TESTS====
gwcs                 0.24.0               https://github.com/spacetelescope/gwcs
tweakwcs             0.8.10               https://github.com/spacetelescope/tweakwcs
stwcs                1.7.5rc0             https://github.com/spacetelescope/stwcs
stsci.stimage        0.3.0                https://github.com/spacetelescope/stsci.stimage
stsci.image          2.3.10               https://github.com/spacetelescope/stsci.image
fitsblender          0.4.4                https://github.com/spacetelescope/fitsblender
spherical_geometry   1.3.3                https://github.com/spacetelescope/spherical_geometry
stsci.tools          4.2.0                https://github.com/spacetelescope/stsci.tools
stsci.skypac         1.0.10               https://github.com/spacetelescope/stsci.skypac
wfpc2tools           1.0.5                https://github.com/spacetelescope/wfpc2tools
wfc3tools            1.5.0                https://github.com/spacetelescope/wfc3tools
stistools            1.4.4                https://github.com/spacetelescope/stistools
nictools             1.1.5                https://github.com/spacetelescope/nictools
crds                 12.1.4               https://github.com/spacetelescope/crds
costools             1.2.6                https://github.com/spacetelescope/costools
calcos               3.6.1                https://github.com/spacetelescope/calcos
stsci.imagestats     (null)               https://github.com/spacetelescope/stsci.imagestats
acstools             3.7.2                https://github.com/spacetelescope/acstools
drizzlepac           3.10.0rc4            https://github.com/spacetelescope/drizzlepac
hstcal               (null)               https://github.com/spacetelescope/hstcal
```