### PR TITLE
to_short_version: drop any values beyond "major.minor"

### DIFF
--- a/src/lib/core/include/str.h
+++ b/src/lib/core/include/str.h
@@ -293,18 +293,27 @@ int isdigit_s(const char *s);
 char *tolower_s(char *s);
 
 /**
- * Return a copy of the input string with "." characters removed
+ * Reduce a version string to the major[minor] format used by Python
  *
- * ~~~{.c}
- * char *version = strdup("1.2.3");
- * char *version_short = to_short_version(str);
- * // version_short is "123"
- * free(version_short);
+ * @code{.c}
+ * #include <stdio.h>
+ * #include "str.h"
  *
- * ~~~
+ * int main(int argc, char *argv[]) {
+ *     char python_version[] = "3.13.3"
+ *     char *python_short_version = to_short_version(python_version);  // "313"
+ *     if (!python_short_version) {
+ *         perror("unable to allocate memory for shortened python version");
+ *         return 1;
+ *     }
+ *     free(python_short_version);
+ *     return 0;
+ * }
+ * @endcode
  *
- * @param s input string
- * @return pointer to new string
+ * @param s python version string
+ * @return the shortened version string
+ * @return NULL on error
  */
 char *to_short_version(const char *s);
 

--- a/src/lib/core/str.c
+++ b/src/lib/core/str.c
@@ -640,12 +640,35 @@ char *tolower_s(char *s) {
 }
 
 char *to_short_version(const char *s) {
-    char *result = strdup(s);
-    if (!result) {
-        return NULL;
+    char *result = NULL;
+    if (num_chars(s, '.') > 1) {
+        char **version_data = split((char *) s, ".", 1);
+        if (!version_data) {
+            goto to_short_version_failed;
+        }
+        if (version_data[1]) {
+            char *dot = strchr(version_data[1], '.');
+            if (dot) {
+                *dot = '\0';
+            }
+        }
+        result = join(version_data, "");
+        if (!result) {
+            guard_array_free(version_data);
+            goto to_short_version_failed;
+        }
+        guard_array_free(version_data);
+    } else {
+        result = strdup(s);
+        if (!result) {
+            goto to_short_version_failed;
+        }
+        strchrdel(result, ".");
     }
-    strchrdel(result, ".");
+
     return result;
+    to_short_version_failed:
+    return NULL;
 }
 
 void unindent(char *s) {

--- a/tests/test_str.c
+++ b/tests/test_str.c
@@ -6,16 +6,17 @@ void test_to_short_version() {
         const char *expected;
     };
 
-    struct testcase tc[] = {
-            {.data = "1.2.3", .expected = "123"},
+    const struct testcase tc[] = {
+            {.data = "1.2.3", .expected = "12"},
             {.data = "py3.12", .expected = "py312"},
-            {.data = "generic-1.2.3", .expected = "generic-123"},
+            {.data = "generic-1.2.3", .expected = "generic-12"},
             {.data = "nothing to do", .expected = "nothing to do"},
     };
 
     for (size_t i = 0; i < sizeof(tc) / sizeof(*tc); i++) {
         char *result = to_short_version(tc[i].data);
         STASIS_ASSERT_FATAL(result != NULL, "should not be NULL");
+        //printf("%s[%zu], result: %s, expected: %s\n", __FUNCTION__, i, result, tc[i].expected);
         STASIS_ASSERT(strcmp(result, tc[i].expected) == 0, "unexpected result");
         guard_free(result);
     }


### PR DESCRIPTION
* Fixes output file names: python=3.13.3 would produce 3133 instead of the expected 313